### PR TITLE
fix: 포켓몬 리스트 구현 수정

### DIFF
--- a/front-end/src/components/pokemon/ListPokemons.jsx
+++ b/front-end/src/components/pokemon/ListPokemons.jsx
@@ -1,5 +1,4 @@
 // Main.js
-import { useState } from "react";
 import { usePokemonSearch } from "../../hooks/usePokemonSearch";
 import {
   Wrapper,
@@ -9,23 +8,15 @@ import {
   Container,
   Img,
   PostItem,
-  Btn,
 } from "../../styles/pokemon/listPokemon.style";
 
 const Main = () => {
   const { pokemons, pokemonName, setPokemonNames, searchPokemon } =
     usePokemonSearch();
 
-  const [visiblePokemons, setVisiblePokemons] = useState(30); // 초기에 10개의 데이터만 보이도록 설정
-
   const handlePokeSearch = (e) => {
     e.preventDefault();
     searchPokemon(pokemonName);
-  };
-
-  const handleLoadMore = () => {
-    // 추가로 10개의 데이터를 보이도록 visiblePokemons 값을 증가시킴
-    setVisiblePokemons((prevVisiblePokemons) => prevVisiblePokemons + 30);
   };
 
   return (
@@ -42,7 +33,7 @@ const Main = () => {
 
       <Container>
         {pokemons &&
-          pokemons.slice(0, visiblePokemons).map((data, index) => (
+          pokemons.map((data, index) => (
             <PostItem to={`/detail/${data.id}`} key={index}>
               {data.imagegif ? (
                 <Img src={data.imagegif} />
@@ -53,10 +44,6 @@ const Main = () => {
             </PostItem>
           ))}
       </Container>
-
-      {pokemons && visiblePokemons < pokemons.length && (
-        <Btn onClick={handleLoadMore}>더 보기</Btn>
-      )}
     </Wrapper>
   );
 };


### PR DESCRIPTION
## 요약

<br>리스트 목록 구현 변경<br>

## 작업 내용

<br>30개의 단위로 잘라서 더보기 버튼 사용 -> 전체 데이터 불러오는 것으로 변경<br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #이슈번호

<br><br>
